### PR TITLE
Replace opn library with open

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const opn = require('opn')
+const open = require('open')
 const express = require('express')
 const chalk = require('chalk')
 const argv = require('minimist')(process.argv.slice(2))
@@ -62,7 +62,7 @@ app.get('/token', (req, res) => {
 const main = () => {
   app.listen(PORT, () => {
     console.log(chalk.blue('Opening the Spotify Login Dialog in your browser...'))
-    opn(URL)
+    open(URL)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clipboardy": "^1.2.3",
     "express": "^4.16.2",
     "minimist": "^1.2.0",
-    "opn": "^5.2.0"
+    "open": "^7.0.4"
   },
   "preferGlobal": true,
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,13 +225,21 @@ ipaddr.js@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
 
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -294,11 +302,13 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-opn@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
+open@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.4.tgz#c28a9d315e5c98340bf979fdcb2e58664aa10d83"
+  integrity sha512-brSA+/yq+b08Hsr4c8fsEW2CRzk1BmfN3SAK/5VCHQ9bdoZJ4qa/+AfR0xHjlbbZUyPkUHs1b8x1RqdyZdkVqQ==
   dependencies:
-    is-wsl "^1.1.0"
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 p-finally@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The author has deprecated the `opn` package and has moved it to `open`

![image](https://user-images.githubusercontent.com/1115318/84076877-86d41c80-a9a4-11ea-8278-dc3aef57e42e.png)

I recently was looking for a package to grab the auth token for a given spotify client_id and came across your package. I realized that the `opn` package was updated by the author, just wanted to drop this PR to reflect that change here.